### PR TITLE
Slight modification of BSPWM polybar layout

### DIFF
--- a/etc/skel/.config/bspwm/polybar/config
+++ b/etc/skel/.config/bspwm/polybar/config
@@ -21,10 +21,10 @@ override-redirect = false
 bottom = false
 fixed-center = true
 
-width = 98%
+width = 99%
 height = 25
 
-offset-x = 1%
+offset-x = 0.5%
 offset-y = 1%
 
 background = ${color.background}


### PR DESCRIPTION
A suggestion to extend the width of polybar so that it aligns vertically with the windows.
It should be consistent with the layout adopted for the i3 desktop.

Before:
![before](https://user-images.githubusercontent.com/49805430/149119648-3f6df9b9-f8f5-4339-b5b5-ea7e08b36d5c.png)

After:
![after](https://user-images.githubusercontent.com/49805430/149119737-b6e05c83-269c-4c2c-a188-efb835526ad9.png)

